### PR TITLE
Linking and auto linking on oauth2 registration

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -623,21 +623,22 @@ REGISTER_EMAIL_CONFIRM =
 OPENID_CONNECT_SCOPES =
 ; Scopes for the google oauth2 provider (seperated by space)
 ; Default scopes will provide only email, but for registration we may need more: email, profile
-GOOGLE_CONNECT_SCOPES =
+GOOGLE_SCOPES =
 ; Automatically create user accounts for new oauth2 users.
 ENABLE_AUTO_REGISTRATION = false
-; Use the nickname attribute from the oauth2 provider instead of the userid as the new username.
-USE_NICKNAME = false
-; Use the username part of email attribute from oauth2 provider instead of userid.
-; This is useful for google ouath2 provider.
-USE_EMAIL = false
+; The source of the username for new oauth2 accounts:
+; userid = use the userid / sub attribute
+; nickname = use the nickname attribute
+; email = use the username part of the email attribute
+USERNAME = userid
 ; Update avatar if available from oauth2 provider.
 ; Update will be performed on each login.
 UPDATE_AVATAR = false
-; If true, show account linking login in case account already exist.
-SHOW_ACCOUNT_LINKING_LOGIN = false
-; If true, automatically link with existing account.
-ENABLE_AUTO_REGISTRATION_LINKING = false
+; How to handle if an account / email already exists:
+; disabled = show an error
+; login = show an account linking login
+; auto = link directly with the account
+ACCOUNT_LINKING = disabled
 
 [service]
 ; Time limit to confirm account/email registration

--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -621,10 +621,23 @@ REGISTER_EMAIL_CONFIRM =
 ; Typical values are profile and email.
 ; For more information about the possible values see https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
 OPENID_CONNECT_SCOPES =
+; Scopes for the google oauth2 provider (seperated by space)
+; Default scopes will provide only email, but for registration we may need more: email, profile
+GOOGLE_CONNECT_SCOPES =
 ; Automatically create user accounts for new oauth2 users.
 ENABLE_AUTO_REGISTRATION = false
 ; Use the nickname attribute from the oauth2 provider instead of the userid as the new username.
 USE_NICKNAME = false
+; Use the username part of email attribute from oauth2 provider instead of userid.
+; This is useful for google ouath2 provider.
+USE_EMAIL = false
+; Update avatar if available from oauth2 provider.
+; Update will be performed on each login.
+UPDATE_AVATAR = false
+; If true, show account linking login in case account already exist.
+SHOW_ACCOUNT_LINKING_LOGIN = false
+; If true, automatically link with existing account.
+ENABLE_AUTO_REGISTRATION_LINKING = false
 
 [service]
 ; Time limit to confirm account/email registration

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -429,8 +429,13 @@ relation to port exhaustion.
 
 - `REGISTER_EMAIL_CONFIRM`: *[service]* **REGISTER\_EMAIL\_CONFIRM**: Set this to enable or disable email confirmation of OAuth2 auto-registration. (Overwrites the REGISTER\_EMAIL\_CONFIRM setting of the `[service]` section)
 - `OPENID_CONNECT_SCOPES`: **\<empty\>**: List of additional openid connect scopes. (`openid` is implicitly added)
+- `GOOGLE_CONNECT_SCOPES`: **\<empty\>**: List of additional google scopes (we may need to write here `email profile`)
 - `ENABLE_AUTO_REGISTRATION`: **false**: Enable this to allow auto-registration for oauth2 authentication.
 - `USE_NICKNAME`: **false**: Set this to use the nickname from the oauth2 provider instead of the userid for the username of the new user.
+- `USE_EMAIL`: **false**: Set this to use username part of email from the oauth2 provider instead of the userid for the username of te new user (useful for google ouath2 provider).
+- `UPDATE_AVATAR`: **false**: Set this to update user avatar if available from the oauth2 provider.
+- `SHOW_ACCOUNT_LINKING_LOGIN`: **false**: Set this to show account linking login in case account already exist.
+- `ENABLE_AUTO_REGISTRATION_LINKING`: **false**: Set this to automatically link with existing account.
 
 ## Service (`service`)
 

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -429,13 +429,11 @@ relation to port exhaustion.
 
 - `REGISTER_EMAIL_CONFIRM`: *[service]* **REGISTER\_EMAIL\_CONFIRM**: Set this to enable or disable email confirmation of OAuth2 auto-registration. (Overwrites the REGISTER\_EMAIL\_CONFIRM setting of the `[service]` section)
 - `OPENID_CONNECT_SCOPES`: **\<empty\>**: List of additional openid connect scopes. (`openid` is implicitly added)
-- `GOOGLE_CONNECT_SCOPES`: **\<empty\>**: List of additional google scopes (we may need to write here `email profile`)
+- `GOOGLE_SCOPES`: **\<empty\>**: List of additional google scopes (we may need to write here `email profile`)
 - `ENABLE_AUTO_REGISTRATION`: **false**: Enable this to allow auto-registration for oauth2 authentication.
-- `USE_NICKNAME`: **false**: Set this to use the nickname from the oauth2 provider instead of the userid for the username of the new user.
-- `USE_EMAIL`: **false**: Set this to use username part of email from the oauth2 provider instead of the userid for the username of te new user (useful for google ouath2 provider).
+- `USERNAME`: **userid**: The source of the username for new oauth2 accounts: userid, nickname, email (username part). 
 - `UPDATE_AVATAR`: **false**: Set this to update user avatar if available from the oauth2 provider.
-- `SHOW_ACCOUNT_LINKING_LOGIN`: **false**: Set this to show account linking login in case account already exist.
-- `ENABLE_AUTO_REGISTRATION_LINKING`: **false**: Set this to automatically link with existing account.
+- `ACCOUNT_LINKING`: **disabled**: How to handle if an account / email already exists: disabled / login / auto.
 
 ## Service (`service`)
 

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -302,6 +302,8 @@ var migrations = []Migration{
 	NewMigration("Remove invalid labels from comments", removeInvalidLabels),
 	// v177 -> v178
 	NewMigration("Delete orphaned IssueLabels", deleteOrphanedIssueLabels),
+	// v178 -> v179
+	NewMigration("Convert avatar url to text", convertAvatarUrlToText),
 }
 
 // GetCurrentDBVersion returns the current db version

--- a/models/migrations/v178.go
+++ b/models/migrations/v178.go
@@ -1,0 +1,22 @@
+package migrations
+
+import (
+	"xorm.io/xorm"
+	"xorm.io/xorm/schemas"
+)
+
+func convertAvatarUrlToText(x *xorm.Engine) error {
+	dbType := x.Dialect().URI().DBType
+	if dbType == schemas.SQLITE { // For SQLITE, varchar or char will always be represented as TEXT
+		return nil
+	}
+
+	// Some oauth2 providers may give very long avatar urls (i.e. Google)
+	return modifyColumn(x, "external_login_user", &schemas.Column{
+		Name: "avatar_url",
+		SQLType: schemas.SQLType{
+			Name: schemas.Text,
+		},
+		Nullable: true,
+	})
+}

--- a/modules/auth/oauth2/oauth2.go
+++ b/modules/auth/oauth2/oauth2.go
@@ -175,7 +175,7 @@ func createProvider(providerName, providerType, clientID, clientSecret, openIDCo
 		}
 		provider = gitlab.NewCustomisedURL(clientID, clientSecret, callbackURL, authURL, tokenURL, profileURL, "read_user")
 	case "gplus": // named gplus due to legacy gplus -> google migration (Google killed Google+). This ensures old connections still work
-		provider = google.New(clientID, clientSecret, callbackURL, setting.OAuth2Client.GoogleConnectScopes...)
+		provider = google.New(clientID, clientSecret, callbackURL, setting.OAuth2Client.GoogleScopes...)
 	case "openidConnect":
 		if provider, err = openidConnect.New(clientID, clientSecret, callbackURL, openIDConnectAutoDiscoveryURL, setting.OAuth2Client.OpenIDConnectScopes...); err != nil {
 			log.Warn("Failed to create OpenID Connect Provider with name '%s' with url '%s': %v", providerName, openIDConnectAutoDiscoveryURL, err)

--- a/modules/auth/oauth2/oauth2.go
+++ b/modules/auth/oauth2/oauth2.go
@@ -175,7 +175,7 @@ func createProvider(providerName, providerType, clientID, clientSecret, openIDCo
 		}
 		provider = gitlab.NewCustomisedURL(clientID, clientSecret, callbackURL, authURL, tokenURL, profileURL, "read_user")
 	case "gplus": // named gplus due to legacy gplus -> google migration (Google killed Google+). This ensures old connections still work
-		provider = google.New(clientID, clientSecret, callbackURL)
+		provider = google.New(clientID, clientSecret, callbackURL, setting.OAuth2Client.GoogleConnectScopes...)
 	case "openidConnect":
 		if provider, err = openidConnect.New(clientID, clientSecret, callbackURL, openIDConnectAutoDiscoveryURL, setting.OAuth2Client.OpenIDConnectScopes...); err != nil {
 			log.Warn("Failed to create OpenID Connect Provider with name '%s' with url '%s': %v", providerName, openIDConnectAutoDiscoveryURL, err)

--- a/modules/setting/service.go
+++ b/modules/setting/service.go
@@ -71,15 +71,13 @@ var Service struct {
 
 // OAuth2Client settings
 var OAuth2Client struct {
-	RegisterEmailConfirm    bool
-	OpenIDConnectScopes     []string
-	GoogleConnectScopes     []string
-	EnableAutoRegistration  bool
-	UseNickname             bool
-	UseEmail                bool
-	UpdateAvatar					  bool
-	AccountLinkingLogin     bool
-	AutoRegistrationLinking bool
+	RegisterEmailConfirm   bool
+	OpenIDConnectScopes    []string
+	GoogleScopes           []string
+	EnableAutoRegistration bool
+	Username               string
+	UpdateAvatar           bool
+	AccountLinking         string
 }
 
 func newService() {
@@ -154,13 +152,39 @@ func newService() {
 	sec = Cfg.Section("oauth2_client")
 	OAuth2Client.RegisterEmailConfirm = sec.Key("REGISTER_EMAIL_CONFIRM").MustBool(Service.RegisterEmailConfirm)
 	OAuth2Client.OpenIDConnectScopes = parseScopes(sec, "OPENID_CONNECT_SCOPES")
-	OAuth2Client.GoogleConnectScopes = parseScopes(sec, "GOOGLE_CONNECT_SCOPES")
+	OAuth2Client.GoogleScopes = parseScopes(sec, "GOOGLE_SCOPES")
 	OAuth2Client.EnableAutoRegistration = sec.Key("ENABLE_AUTO_REGISTRATION").MustBool()
-	OAuth2Client.UseNickname = sec.Key("USE_NICKNAME").MustBool()
-	OAuth2Client.UseEmail = sec.Key("USE_EMAIL").MustBool()
+	OAuth2Client.Username = sec.Key("USERNAME").MustString("userid")
+	if !isValidUsername(OAuth2Client.Username) {
+		log.Warn("Username setting is not valid: '%s', will fallback to 'userid'", OAuth2Client.Username)
+		OAuth2Client.Username = "userid"
+	}
 	OAuth2Client.UpdateAvatar = sec.Key("UPDATE_AVATAR").MustBool()
-	OAuth2Client.AccountLinkingLogin = sec.Key("SHOW_ACCOUNT_LINKING_LOGIN").MustBool(true)
-	OAuth2Client.AutoRegistrationLinking = sec.Key("ENABLE_AUTO_REGISTRATION_LINKING").MustBool()
+	OAuth2Client.AccountLinking = sec.Key("ACCOUNT_LINKING").MustString("ACCOUNT_LINKING")
+	if !isValidAccountLinking(OAuth2Client.AccountLinking) {
+		log.Warn("Account linking setting is not valid: '%s', will fallback to 'disabled'")
+		OAuth2Client.AccountLinking = "disabled"
+	}
+}
+
+func isValidUsername(username string) bool {
+	switch username {
+	case "userid":
+	case "nickname":
+	case "email":
+		return true
+	}
+	return false
+}
+
+func isValidAccountLinking(accountLinking string) bool {
+	switch accountLinking {
+	case "disabled":
+	case "login":
+	case "auto":
+		return true
+	}
+	return false
 }
 
 func parseScopes(sec *ini.Section, name string) []string {

--- a/modules/setting/service.go
+++ b/modules/setting/service.go
@@ -5,6 +5,7 @@
 package setting
 
 import (
+	"gopkg.in/ini.v1"
 	"regexp"
 	"time"
 
@@ -70,10 +71,15 @@ var Service struct {
 
 // OAuth2Client settings
 var OAuth2Client struct {
-	RegisterEmailConfirm   bool
-	OpenIDConnectScopes    []string
-	EnableAutoRegistration bool
-	UseNickname            bool
+	RegisterEmailConfirm    bool
+	OpenIDConnectScopes     []string
+	GoogleConnectScopes     []string
+	EnableAutoRegistration  bool
+	UseNickname             bool
+	UseEmail                bool
+	UpdateAvatar					  bool
+	AccountLinkingLogin     bool
+	AutoRegistrationLinking bool
 }
 
 func newService() {
@@ -147,13 +153,23 @@ func newService() {
 
 	sec = Cfg.Section("oauth2_client")
 	OAuth2Client.RegisterEmailConfirm = sec.Key("REGISTER_EMAIL_CONFIRM").MustBool(Service.RegisterEmailConfirm)
-	pats = sec.Key("OPENID_CONNECT_SCOPES").Strings(" ")
-	OAuth2Client.OpenIDConnectScopes = make([]string, 0, len(pats))
-	for _, scope := range pats {
-		if scope != "" {
-			OAuth2Client.OpenIDConnectScopes = append(OAuth2Client.OpenIDConnectScopes, scope)
-		}
-	}
+	OAuth2Client.OpenIDConnectScopes = parseScopes(sec, "OPENID_CONNECT_SCOPES")
+	OAuth2Client.GoogleConnectScopes = parseScopes(sec, "GOOGLE_CONNECT_SCOPES")
 	OAuth2Client.EnableAutoRegistration = sec.Key("ENABLE_AUTO_REGISTRATION").MustBool()
 	OAuth2Client.UseNickname = sec.Key("USE_NICKNAME").MustBool()
+	OAuth2Client.UseEmail = sec.Key("USE_EMAIL").MustBool()
+	OAuth2Client.UpdateAvatar = sec.Key("UPDATE_AVATAR").MustBool()
+	OAuth2Client.AccountLinkingLogin = sec.Key("SHOW_ACCOUNT_LINKING_LOGIN").MustBool(true)
+	OAuth2Client.AutoRegistrationLinking = sec.Key("ENABLE_AUTO_REGISTRATION_LINKING").MustBool()
+}
+
+func parseScopes(sec *ini.Section, name string) []string {
+	parts := sec.Key(name).Strings(" ")
+	scopes := make([]string, 0, len(parts))
+	for _, scope :=	 range parts {
+		if scope != "" {
+			scopes = append(scopes, scope)
+		}
+	}
+	return scopes
 }

--- a/routers/user/auth_openid.go
+++ b/routers/user/auth_openid.go
@@ -415,7 +415,7 @@ func RegisterOpenIDPost(ctx *context.Context) {
 		Passwd:   password,
 		IsActive: !(setting.Service.RegisterEmailConfirm || setting.Service.RegisterManualConfirm),
 	}
-	if !createUserInContext(ctx, tplSignUpOID, form, u) {
+	if ok, _ := createUserInContext(ctx, tplSignUpOID, form, u, false); !ok {
 		// error already handled
 		return
 	}

--- a/routers/user/auth_openid.go
+++ b/routers/user/auth_openid.go
@@ -415,7 +415,7 @@ func RegisterOpenIDPost(ctx *context.Context) {
 		Passwd:   password,
 		IsActive: !(setting.Service.RegisterEmailConfirm || setting.Service.RegisterManualConfirm),
 	}
-	if ok, _ := createUserInContext(ctx, tplSignUpOID, form, u, false); !ok {
+	if !createUserInContext(ctx, tplSignUpOID, form, u, nil, false) {
 		// error already handled
 		return
 	}


### PR DESCRIPTION
Added option GOOGLE_CONNECT_SCOPES - scopes for google provider (we're using this one). There is no profile information without profile scope.
Added option USE_EMAIL - to use username part of email for 'name'. This is extremly usefull for google provider.
Added option SHOW_ACCOUNT_LINKING_LOGIN - if enabled account linking login page will be displayed in case already exist.
Added option ENABLE_AUTO_REGISTRATION_LINKING - if enabled account will be linked automatically in case already exist.
Added option UPDATE_AVATAR - avatar will be automatically updated on login if enabled and avatar_url is available from ouath2 provider
Added migration for avatar_url in external_login_user. Currently it is restricted to 255 chars, but google sends us urls 850 chars len.
Some side effects: If you have (for example) two auths - ldap and google. If user will register with ldap and later will try to login with google - it will work. But if user will register with google he will be not able to login/link with ldap credentials. This is cause of user accounts design in gitea.

Also this patch does not respect 'remember' option in case of auto linking.

----

Part of go-gitea/gitea#5123